### PR TITLE
🐛 Render blog OG cards at 2x opaque RGB (fix LinkedIn blur)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,11 @@
       "dependencies": {
         "@astrojs/sitemap": "^3.7.2",
         "@fontsource/merriweather": "^5.0.0",
+        "@resvg/resvg-js": "^2.6.2",
         "astro": "^6.4.6",
-        "astro-og-canvas": "^0.13.0",
         "remark-github-blockquote-alert": "^2.1.0",
         "remark-smartypants": "^3.0.0",
+        "satori": "^0.26.0",
         "sharp": "^0.33.0"
       },
       "devDependencies": {
@@ -1142,6 +1143,233 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -1595,6 +1823,22 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1672,12 +1916,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
-    },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
-      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -1821,32 +2059,6 @@
       },
       "optionalDependencies": {
         "sharp": "^0.34.0"
-      }
-    },
-    "node_modules/astro-og-canvas": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/astro-og-canvas/-/astro-og-canvas-0.13.0.tgz",
-      "integrity": "sha512-jcIDhE9OGIbd7LstZQ4CyzOpbbEKAlxJqEgdkVu6r26m7yJKlQjKysszfDxlox717cnCLPXKivyFjsufcq8sYA==",
-      "license": "MIT",
-      "dependencies": {
-        "canvaskit-wasm": "^0.41.1",
-        "deterministic-object-hash": "^2.0.2",
-        "entities": "^8.0.0"
-      },
-      "peerDependencies": {
-        "astro": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      }
-    },
-    "node_modules/astro-og-canvas/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/astro/node_modules/@astrojs/compiler": {
@@ -2287,11 +2499,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-      "license": "MIT"
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -2312,13 +2527,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/canvaskit-wasm": {
-      "version": "0.41.1",
-      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.41.1.tgz",
-      "integrity": "sha512-gO2rNMIE0lOQ8MaarM4qNeq2zZAEknAObKP2XAKidMSAY8P5sURGdFkrx1TSdHuBFqTf5w35JqjuUzjibqkD5g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@webgpu/types": "0.1.21"
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ccount": {
@@ -2505,6 +2720,36 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -2519,6 +2764,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -2637,18 +2893,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/deterministic-object-hash": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
-      "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-64": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/devalue": {
@@ -2775,6 +3019,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2833,6 +3086,12 @@
         "@esbuild/win32-ia32": "0.27.4",
         "@esbuild/win32-x64": "0.27.4"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -2925,6 +3184,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
     },
     "node_modules/filename-reserved-regex": {
       "version": "2.0.0",
@@ -3337,6 +3602,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -3531,6 +3808,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -4672,6 +4959,22 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -4833,6 +5136,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/prettier": {
       "version": "3.6.2",
@@ -5271,6 +5580,28 @@
         "suf-log": "^2.5.3"
       }
     },
+    "node_modules/satori": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
+      "integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -5429,6 +5760,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
       "license": "MIT"
     },
     "node_modules/stringify-entities": {
@@ -5638,6 +5975,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -6078,6 +6425,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   "dependencies": {
     "@astrojs/sitemap": "^3.7.2",
     "@fontsource/merriweather": "^5.0.0",
+    "@resvg/resvg-js": "^2.6.2",
     "astro": "^6.4.6",
-    "astro-og-canvas": "^0.13.0",
     "remark-github-blockquote-alert": "^2.1.0",
     "remark-smartypants": "^3.0.0",
+    "satori": "^0.26.0",
     "sharp": "^0.33.0"
   },
   "devDependencies": {

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -48,8 +48,8 @@ const twitterCard = largeCard ? "summary_large_image" : "summary"
   largeCard && (
     <>
       <meta property="og:image:type" content="image/png" />
-      <meta property="og:image:width" content="1200" />
-      <meta property="og:image:height" content="630" />
+      <meta property="og:image:width" content="2400" />
+      <meta property="og:image:height" content="1260" />
       <meta property="og:image:alt" content={title} />
     </>
   )

--- a/src/pages/blog/og/[...slug].png.ts
+++ b/src/pages/blog/og/[...slug].png.ts
@@ -1,29 +1,44 @@
-import { OGImageRoute } from "astro-og-canvas"
+import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
+import { readFile } from "node:fs/promises"
+import satori from "satori"
+import { Resvg } from "@resvg/resvg-js"
+import sharp from "sharp"
 import { getSlug } from "../../../utils/slug"
 
-// Build a map of blog-post slug -> post entry. astro-og-canvas turns each
-// entry into a statically-generated PNG at `/blog/og/<slug>.png`.
-const posts = await getCollection("blog")
-const pages = Object.fromEntries(posts.map((post) => [getSlug(post.id), post]))
+// Open Graph "title card" generator for blog posts.
+//
+// Rendered with satori (layout -> SVG) then rasterized with resvg at 2x
+// (2400x1260) for crisp text, and finally flattened with sharp to strip the
+// alpha channel. LinkedIn mishandles PNG transparency: it downscaled the old
+// RGBA card to a tiny `articleshare-shrink_160` derivative and showed it
+// blurry. An opaque RGB PNG at 2x avoids that. The design is unchanged from
+// the previous astro-og-canvas card: a #06ff68 accent bar, a white Open Sans
+// title, and a green "Johnathan Gilday · johnathangilday.com" byline.
 
-// Brand palette (mirrors the blog's dark-mode theme in src/styles/blog.css):
-//   background  #121212  -> [18, 18, 18]
-//   accent      #06ff68  -> [6, 255, 104]
-//   text        #ffffff  -> [255, 255, 255]
-const ACCENT: [number, number, number] = [6, 255, 104]
-const TEXT: [number, number, number] = [255, 255, 255]
+// Logical card dimensions. resvg upscales to 2x (see SCALE) when rasterizing,
+// so the emitted PNG is CARD_WIDTH*SCALE x CARD_HEIGHT*SCALE (2400x1260).
+const CARD_WIDTH = 1200
+const CARD_HEIGHT = 630
+const SCALE = 2
+
+// Brand palette (mirrors the blog's dark-mode theme in src/styles/blog.css).
+const BG_DARK = "rgb(18, 18, 18)" // #121212
+const BG_LIGHT = "rgb(30, 30, 30)" // subtle gradient partner
+const ACCENT = "rgb(6, 255, 104)" // #06ff68
+const TEXT = "rgb(255, 255, 255)" // #ffffff
+const FLATTEN_BG = "#121212" // opaque backstop when dropping alpha
+
+const fontBold = await readFile("./src/assets/fonts/OpenSans-Bold.ttf")
+const fontRegular = await readFile("./src/assets/fonts/OpenSans-Regular.ttf")
 
 /**
  * Some post titles lead with a decorative emoji (e.g. "🔒 XML External Entity…").
- * canvaskit has no emoji font loaded, so it drops the glyph but keeps the
- * trailing space, leaving the card title visibly indented. Strip any leading
- * run of pictographic characters, emoji modifiers, and the whitespace that
- * follows so the rendered title starts flush. The full title (emoji and all)
- * is kept for og:image:alt over in BaseHead.astro.
- *
- * Char class: any Extended_Pictographic glyph, U+FE0F (variation selector-16),
- * U+200D (zero-width joiner in emoji sequences), and any whitespace.
+ * We have no emoji font loaded, so strip any leading run of pictographic
+ * characters, emoji modifiers (U+FE0F variation selector, U+200D zero-width
+ * joiner), and the whitespace that follows so the rendered title starts flush.
+ * The full original title (emoji and all) is still used for og:image:alt in
+ * BaseHead.astro.
  */
 function cardTitle(title: string): string {
   return title
@@ -31,41 +46,96 @@ function cardTitle(title: string): string {
     .trimStart()
 }
 
-export const { getStaticPaths, GET } = await OGImageRoute({
-  pages,
-  // The map key is already the post slug; use it verbatim as the route param.
-  getSlug: (path) => path,
-  getImageOptions: (_path, post) => ({
-    title: cardTitle(post.data.title),
-    // Card sub-text: author + domain (the SEO og:description is set separately
-    // in BaseHead.astro). Middle dot instead of an em dash by house style.
-    description: "Johnathan Gilday · johnathangilday.com",
-    bgGradient: [
-      [18, 18, 18],
-      [30, 30, 30],
-    ],
-    // Accent bar down the leading edge — the one brand motif, kept subtle.
-    border: { color: ACCENT, width: 24, side: "inline-start" },
-    padding: 80,
-    font: {
-      title: {
-        color: TEXT,
-        size: 68,
-        lineHeight: 1.1,
-        weight: "bold",
-        families: ["Open Sans"],
-      },
-      description: {
-        color: ACCENT,
-        size: 30,
-        weight: "normal",
-        families: ["Open Sans"],
-      },
+/** Minimal hyperscript so we can build satori's element tree without JSX. */
+function el(type: string, style: Record<string, unknown>, children: unknown) {
+  return { type, props: { style, children } }
+}
+
+function card(title: string) {
+  return el(
+    "div",
+    {
+      width: "100%",
+      height: "100%",
+      display: "flex",
+      backgroundImage: `linear-gradient(135deg, ${BG_DARK}, ${BG_LIGHT})`,
+      fontFamily: "Open Sans",
     },
+    [
+      // Accent bar down the leading edge — the one brand motif, kept subtle.
+      el(
+        "div",
+        { width: "24px", height: "100%", backgroundColor: ACCENT, flexShrink: 0 },
+        ""
+      ),
+      el(
+        "div",
+        { display: "flex", flexDirection: "column", flex: 1, padding: "80px" },
+        [
+          el(
+            "div",
+            {
+              fontSize: "68px",
+              fontWeight: 700,
+              lineHeight: 1.1,
+              color: TEXT,
+              // `display: flex` lets satori wrap long titles across lines.
+              display: "flex",
+            },
+            title
+          ),
+          el(
+            "div",
+            {
+              fontSize: "30px",
+              fontWeight: 400,
+              color: ACCENT,
+              marginTop: "30px",
+            },
+            "Johnathan Gilday · johnathangilday.com"
+          ),
+        ]
+      ),
+    ]
+  )
+}
+
+export function getStaticPaths() {
+  return getCollection("blog").then((posts) =>
+    posts.map((post) => ({
+      params: { slug: getSlug(post.id) },
+      props: { title: post.data.title },
+    }))
+  )
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const svg = await satori(card(cardTitle(props.title as string)) as never, {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
     fonts: [
-      "./src/assets/fonts/OpenSans-Bold.ttf",
-      "./src/assets/fonts/OpenSans-Regular.ttf",
+      { name: "Open Sans", data: fontBold, weight: 700, style: "normal" },
+      { name: "Open Sans", data: fontRegular, weight: 400, style: "normal" },
     ],
-    format: "PNG",
-  }),
-})
+  })
+
+  // Rasterize the vector SVG at 2x for crisp text at the target resolution.
+  const rendered = new Resvg(svg, {
+    fitTo: { mode: "width", value: CARD_WIDTH * SCALE },
+    background: FLATTEN_BG,
+  }).render()
+
+  // Flatten onto the solid brand background to guarantee an opaque RGB PNG
+  // with no alpha channel (LinkedIn mishandles PNG transparency).
+  const png = await sharp(rendered.asPng())
+    .flatten({ background: FLATTEN_BG })
+    .png()
+    .toBuffer()
+
+  return new Response(new Uint8Array(png), {
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  })
+}


### PR DESCRIPTION
LinkedIn renders the blog Open Graph title cards blurry. Confirmed this is **not** a cache issue: a fresh `?v=2` scrape still returns a low-res, upscaled image because LinkedIn stored a tiny `articleshare-shrink_160` (160px) derivative. Root cause: the deployed card was a 1200x630 PNG with an **alpha channel** (8-bit RGBA), and LinkedIn mishandles PNG transparency by downscaling to a small derivative.

## Fix

1. **Opaque RGB, no alpha.** The card emits an opaque RGB PNG (no alpha channel). Since the background is solid dark, flattening changes nothing visually.
2. **2x resolution.** Rendered at 2400x1260 (same layout, double the pixels). `og:image:width`/`og:image:height` updated to 2400/1260; `twitter:card` stays `summary_large_image`.

## Approach: migrate to satori + @resvg/resvg-js (+ sharp)

astro-og-canvas 0.13 can neither set a custom output size nor drop the alpha channel (its `OGImageOptions` has no width/height/scale, and canvaskit emits RGBA), so post-processing alone could only upscale a low-res render. I migrated the OG route (`src/pages/blog/og/[...slug].png.ts`) to:

- **satori** — builds the card layout as an SVG (vector).
- **@resvg/resvg-js** — rasterizes the SVG at 2x (`fitTo` width 2400) for crisp text.
- **sharp** (already a dependency) — `flatten({ background: "#121212" })` to guarantee an opaque RGB PNG with no alpha channel.

Dropped the now-unused `astro-og-canvas` dependency.

## Unchanged from the merged version

Green `#06ff68` accent bar, white Open Sans title, green `Johnathan Gilday · johnathangilday.com` byline, the leading-emoji strip + `trimStart`, and the full original title (with emoji) kept in `og:image:alt`.

## Verification (`astro build` passes)

    $ file dist/blog/og/owasp-xxe-jaxb.png
    dist/blog/og/owasp-xxe-jaxb.png: PNG image data, 2400 x 1260, 8-bit/color RGB, non-interlaced

    $ sips -g pixelWidth -g pixelHeight -g hasAlpha dist/blog/og/owasp-xxe-jaxb.png
      pixelWidth: 2400
      pixelHeight: 1260
      hasAlpha: no

All 10 generated cards are RGB (none RGBA). Built post HTML shows `og:image:width=2400`, `og:image:height=1260`, `twitter:card=summary_large_image`, and an absolute `og:image` URL.

## How to verify after deploy

Run a post URL (e.g. https://johnathangilday.com/blog/owasp-xxe-jaxb/) through the LinkedIn Post Inspector (https://www.linkedin.com/post-inspector/) to force a re-scrape. The stored image should now be the full-resolution opaque card, not the blurry `articleshare-shrink_160` derivative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)